### PR TITLE
HYDRAN-110: Refactor batch creation

### DIFF
--- a/src/main/java/se/sundsvall/snailmail/service/BatchService.java
+++ b/src/main/java/se/sundsvall/snailmail/service/BatchService.java
@@ -42,7 +42,6 @@ public class BatchService {
 			return entity;
 		}
 
-		LOGGER.info("Creating new batch: {}", LogUtils.sanitizeForLogging(request.getBatchId()));
 		return createBatch(request);
 	}
 
@@ -54,7 +53,8 @@ public class BatchService {
 	 * Ensures that a new transaction is started and committed when inserting entities.
 	 */
 	@Transactional(REQUIRES_NEW)
-	private BatchEntity createBatch(final SendSnailMailRequest request) {
+	public BatchEntity createBatch(final SendSnailMailRequest request) {
+		LOGGER.info("Creating new batch: {}", LogUtils.sanitizeForLogging(request.getBatchId()));
 		final var entity = toBatchEntity(request);
 		return batchRepository.save(entity);
 	}

--- a/src/main/java/se/sundsvall/snailmail/service/BatchService.java
+++ b/src/main/java/se/sundsvall/snailmail/service/BatchService.java
@@ -4,6 +4,11 @@ import static jakarta.transaction.Transactional.TxType.REQUIRES_NEW;
 import static se.sundsvall.snailmail.service.Mapper.toBatchEntity;
 
 import jakarta.transaction.Transactional;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import se.sundsvall.snailmail.api.model.SendSnailMailRequest;
 import se.sundsvall.snailmail.integration.db.BatchRepository;
@@ -12,21 +17,43 @@ import se.sundsvall.snailmail.integration.db.model.BatchEntity;
 @Service
 public class BatchService {
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(BatchService.class);
+
 	private final BatchRepository batchRepository;
 
 	public BatchService(final BatchRepository batchRepository) {
 		this.batchRepository = batchRepository;
 	}
 
-	public BatchRepository getRepository() {
-		return batchRepository;
+	public Optional<BatchEntity> findBatchByMunicipalityIdAndId(final String municipalityId, final String id) {
+		return batchRepository.findByMunicipalityIdAndId(municipalityId, id);
+	}
+
+	public List<BatchEntity> findOutdatedBatches(final OffsetDateTime outdatedBefore) {
+		return batchRepository.findBatchEntityByCreatedIsBefore(outdatedBefore);
+	}
+
+	public BatchEntity getOrCreateBatch(final SendSnailMailRequest request) {
+		final var existingBatchEntity = batchRepository.findByMunicipalityIdAndId(request.getMunicipalityId(), request.getBatchId());
+		if (existingBatchEntity.isPresent()) {
+			final var entity = existingBatchEntity.get();
+			LOGGER.info("Found existing batch: {}", entity.getId());
+			return entity;
+		}
+
+		LOGGER.info("Creating new batch: {}", request.getBatchId());
+		return createBatch(request);
+	}
+
+	public void deleteBatch(final BatchEntity batchEntity) {
+		batchRepository.delete(batchEntity);
 	}
 
 	/**
-	 * Ensures that a new transaction is started and committed when inserting batch entities.
+	 * Ensures that a new transaction is started and committed when inserting entities.
 	 */
 	@Transactional(REQUIRES_NEW)
-	public BatchEntity createEntity(SendSnailMailRequest request) {
+	private BatchEntity createBatch(final SendSnailMailRequest request) {
 		final var entity = toBatchEntity(request);
 		return batchRepository.save(entity);
 	}

--- a/src/main/java/se/sundsvall/snailmail/service/BatchService.java
+++ b/src/main/java/se/sundsvall/snailmail/service/BatchService.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import se.sundsvall.dept44.util.LogUtils;
 import se.sundsvall.snailmail.api.model.SendSnailMailRequest;
 import se.sundsvall.snailmail.integration.db.BatchRepository;
 import se.sundsvall.snailmail.integration.db.model.BatchEntity;
@@ -41,7 +42,7 @@ public class BatchService {
 			return entity;
 		}
 
-		LOGGER.info("Creating new batch: {}", request.getBatchId());
+		LOGGER.info("Creating new batch: {}", LogUtils.sanitizeForLogging(request.getBatchId()));
 		return createBatch(request);
 	}
 

--- a/src/main/java/se/sundsvall/snailmail/service/BatchService.java
+++ b/src/main/java/se/sundsvall/snailmail/service/BatchService.java
@@ -1,0 +1,33 @@
+package se.sundsvall.snailmail.service;
+
+import static jakarta.transaction.Transactional.TxType.REQUIRES_NEW;
+import static se.sundsvall.snailmail.service.Mapper.toBatchEntity;
+
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+import se.sundsvall.snailmail.api.model.SendSnailMailRequest;
+import se.sundsvall.snailmail.integration.db.BatchRepository;
+import se.sundsvall.snailmail.integration.db.model.BatchEntity;
+
+@Service
+public class BatchService {
+
+	private final BatchRepository batchRepository;
+
+	public BatchService(final BatchRepository batchRepository) {
+		this.batchRepository = batchRepository;
+	}
+
+	public BatchRepository getRepository() {
+		return batchRepository;
+	}
+
+	/**
+	 * Ensures that a new transaction is started and committed when inserting batch entities.
+	 */
+	@Transactional(REQUIRES_NEW)
+	public BatchEntity createEntity(SendSnailMailRequest request) {
+		final var entity = toBatchEntity(request);
+		return batchRepository.save(entity);
+	}
+}

--- a/src/main/java/se/sundsvall/snailmail/service/BatchService.java
+++ b/src/main/java/se/sundsvall/snailmail/service/BatchService.java
@@ -34,6 +34,10 @@ public class BatchService {
 		return batchRepository.findBatchEntityByCreatedIsBefore(outdatedBefore);
 	}
 
+	/**
+	 * Ensures that a new transaction is started
+	 */
+	@Transactional(REQUIRES_NEW)
 	public BatchEntity getOrCreateBatch(final SendSnailMailRequest request) {
 		final var existingBatchEntity = batchRepository.findByMunicipalityIdAndId(request.getMunicipalityId(), request.getBatchId());
 		if (existingBatchEntity.isPresent()) {
@@ -42,20 +46,12 @@ public class BatchService {
 			return entity;
 		}
 
-		return createBatch(request);
+		LOGGER.info("Creating new batch: {}", LogUtils.sanitizeForLogging(request.getBatchId()));
+		final var entity = toBatchEntity(request);
+		return batchRepository.save(entity);
 	}
 
 	public void deleteBatch(final BatchEntity batchEntity) {
 		batchRepository.delete(batchEntity);
-	}
-
-	/**
-	 * Ensures that a new transaction is started and committed when inserting entities.
-	 */
-	@Transactional(REQUIRES_NEW)
-	public BatchEntity createBatch(final SendSnailMailRequest request) {
-		LOGGER.info("Creating new batch: {}", LogUtils.sanitizeForLogging(request.getBatchId()));
-		final var entity = toBatchEntity(request);
-		return batchRepository.save(entity);
 	}
 }

--- a/src/main/java/se/sundsvall/snailmail/service/DepartmentService.java
+++ b/src/main/java/se/sundsvall/snailmail/service/DepartmentService.java
@@ -31,9 +31,6 @@ public class DepartmentService {
 			return entity;
 		}
 
-		LOGGER.info("Creating new department: {} for batch: {}",
-			LogUtils.sanitizeForLogging(departmentName),
-			LogUtils.sanitizeForLogging(batchEntity.getId()));
 		return createDepartment(departmentName, batchEntity);
 	}
 
@@ -41,7 +38,10 @@ public class DepartmentService {
 	 * Ensures that a new transaction is started and committed when inserting entities.
 	 */
 	@Transactional(REQUIRES_NEW)
-	private DepartmentEntity createDepartment(final String departmentName, final BatchEntity batch) {
+	public DepartmentEntity createDepartment(final String departmentName, final BatchEntity batch) {
+		LOGGER.info("Creating new department: {} for batch: {}",
+			LogUtils.sanitizeForLogging(departmentName),
+			LogUtils.sanitizeForLogging(batch.getId()));
 		final var entity = toDepartment(departmentName, batch);
 		return departmentRepository.save(entity);
 	}

--- a/src/main/java/se/sundsvall/snailmail/service/DepartmentService.java
+++ b/src/main/java/se/sundsvall/snailmail/service/DepartmentService.java
@@ -1,0 +1,45 @@
+package se.sundsvall.snailmail.service;
+
+import static jakarta.transaction.Transactional.TxType.REQUIRES_NEW;
+import static se.sundsvall.snailmail.service.Mapper.toDepartment;
+
+import jakarta.transaction.Transactional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import se.sundsvall.snailmail.integration.db.DepartmentRepository;
+import se.sundsvall.snailmail.integration.db.model.BatchEntity;
+import se.sundsvall.snailmail.integration.db.model.DepartmentEntity;
+
+@Service
+public class DepartmentService {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(DepartmentService.class);
+
+	private final DepartmentRepository departmentRepository;
+
+	public DepartmentService(final DepartmentRepository departmentRepository) {
+		this.departmentRepository = departmentRepository;
+	}
+
+	public DepartmentEntity getOrCreateDepartment(final String departmentName, final BatchEntity batchEntity) {
+		final var existingDepartmentEntity = departmentRepository.findByNameAndBatchEntityId(departmentName, batchEntity.getId());
+		if (existingDepartmentEntity.isPresent()) {
+			final var entity = existingDepartmentEntity.get();
+			LOGGER.info("Found existing department: {}", entity.getId());
+			return entity;
+		}
+
+		LOGGER.info("Creating new department: {} for batch: {}", departmentName, batchEntity.getId());
+		return createDepartment(departmentName, batchEntity);
+	}
+
+	/**
+	 * Ensures that a new transaction is started and committed when inserting entities.
+	 */
+	@Transactional(REQUIRES_NEW)
+	private DepartmentEntity createDepartment(final String departmentName, final BatchEntity batch) {
+		final var entity = toDepartment(departmentName, batch);
+		return departmentRepository.save(entity);
+	}
+}

--- a/src/main/java/se/sundsvall/snailmail/service/DepartmentService.java
+++ b/src/main/java/se/sundsvall/snailmail/service/DepartmentService.java
@@ -23,6 +23,10 @@ public class DepartmentService {
 		this.departmentRepository = departmentRepository;
 	}
 
+	/**
+	 * Ensures that a new transaction is started
+	 */
+	@Transactional(REQUIRES_NEW)
 	public DepartmentEntity getOrCreateDepartment(final String departmentName, final BatchEntity batchEntity) {
 		final var existingDepartmentEntity = departmentRepository.findByNameAndBatchEntityId(departmentName, batchEntity.getId());
 		if (existingDepartmentEntity.isPresent()) {
@@ -31,18 +35,10 @@ public class DepartmentService {
 			return entity;
 		}
 
-		return createDepartment(departmentName, batchEntity);
-	}
-
-	/**
-	 * Ensures that a new transaction is started and committed when inserting entities.
-	 */
-	@Transactional(REQUIRES_NEW)
-	public DepartmentEntity createDepartment(final String departmentName, final BatchEntity batch) {
 		LOGGER.info("Creating new department: {} for batch: {}",
 			LogUtils.sanitizeForLogging(departmentName),
-			LogUtils.sanitizeForLogging(batch.getId()));
-		final var entity = toDepartment(departmentName, batch);
+			LogUtils.sanitizeForLogging(batchEntity.getId()));
+		final var entity = toDepartment(departmentName, batchEntity);
 		return departmentRepository.save(entity);
 	}
 }

--- a/src/main/java/se/sundsvall/snailmail/service/DepartmentService.java
+++ b/src/main/java/se/sundsvall/snailmail/service/DepartmentService.java
@@ -7,6 +7,7 @@ import jakarta.transaction.Transactional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import se.sundsvall.dept44.util.LogUtils;
 import se.sundsvall.snailmail.integration.db.DepartmentRepository;
 import se.sundsvall.snailmail.integration.db.model.BatchEntity;
 import se.sundsvall.snailmail.integration.db.model.DepartmentEntity;
@@ -30,7 +31,9 @@ public class DepartmentService {
 			return entity;
 		}
 
-		LOGGER.info("Creating new department: {} for batch: {}", departmentName, batchEntity.getId());
+		LOGGER.info("Creating new department: {} for batch: {}",
+			LogUtils.sanitizeForLogging(departmentName),
+			LogUtils.sanitizeForLogging(batchEntity.getId()));
 		return createDepartment(departmentName, batchEntity);
 	}
 

--- a/src/main/java/se/sundsvall/snailmail/service/SnailMailService.java
+++ b/src/main/java/se/sundsvall/snailmail/service/SnailMailService.java
@@ -1,7 +1,9 @@
 package se.sundsvall.snailmail.service;
 
 import static org.zalando.problem.Status.INTERNAL_SERVER_ERROR;
-import static se.sundsvall.snailmail.service.Mapper.*;
+import static se.sundsvall.snailmail.service.Mapper.toDepartment;
+import static se.sundsvall.snailmail.service.Mapper.toRecipient;
+import static se.sundsvall.snailmail.service.Mapper.toRequest;
 
 import java.time.OffsetDateTime;
 import java.util.List;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,7 @@ spring:
     driver-class-name: org.mariadb.jdbc.Driver
     hikari:
       connection-timeout: 5000
+      transaction-isolation: TRANSACTION_READ_COMMITTED
   main:
     banner-mode: 'off'
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,7 @@ spring:
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver
     hikari:
+      maximum-pool-size: 20
       connection-timeout: 5000
       transaction-isolation: TRANSACTION_READ_COMMITTED
   main:

--- a/src/test/java/se/sundsvall/snailmail/service/BatchServiceTest.java
+++ b/src/test/java/se/sundsvall/snailmail/service/BatchServiceTest.java
@@ -1,7 +1,8 @@
 package se.sundsvall.snailmail.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -43,8 +44,8 @@ class BatchServiceTest {
 		when(batchRepositoryMock.findByMunicipalityIdAndId(MUNICIPALITY_ID, BATCH_ID)).thenReturn(Optional.of(expectedEntity));
 
 		final var result = batchService.getOrCreateBatch(request);
-		assertEquals(BATCH_ID, result.getId());
-		assertEquals(MUNICIPALITY_ID, result.getMunicipalityId());
+		assertThat(BATCH_ID).isEqualTo(result.getId());
+		assertThat(MUNICIPALITY_ID).isEqualTo(result.getMunicipalityId());
 
 		verify(batchRepositoryMock, never()).save(any());
 	}
@@ -63,14 +64,42 @@ class BatchServiceTest {
 		when(batchRepositoryMock.save(any(BatchEntity.class))).thenReturn(expectedEntity);
 
 		final var result = batchService.getOrCreateBatch(request);
-		assertEquals(BATCH_ID, result.getId());
-		assertEquals(MUNICIPALITY_ID, result.getMunicipalityId());
+		assertThat(BATCH_ID).isEqualTo(result.getId());
+		assertThat(MUNICIPALITY_ID).isEqualTo(result.getMunicipalityId());
 
 		final var captor = ArgumentCaptor.forClass(BatchEntity.class);
 		verify(batchRepositoryMock).save(captor.capture());
 
 		final var value = captor.getValue();
-		assertEquals(BATCH_ID, value.getId());
-		assertEquals(MUNICIPALITY_ID, value.getMunicipalityId());
+		assertThat(BATCH_ID).isEqualTo(value.getId());
+		assertThat(MUNICIPALITY_ID).isEqualTo(value.getMunicipalityId());
+	}
+
+	@Test
+	void deleteBatch() {
+		final var batchEntity = BatchEntity.builder()
+			.withId(BATCH_ID)
+			.build();
+
+		batchService.deleteBatch(batchEntity);
+
+		verify(batchRepositoryMock).delete(eq(batchEntity));
+	}
+
+	@Test
+	void createBatch() {
+		final var request = SendSnailMailRequest.builder()
+			.withBatchId(BATCH_ID)
+			.withMunicipalityId(MUNICIPALITY_ID)
+			.build();
+
+		batchService.createBatch(request);
+
+		final var captor = ArgumentCaptor.forClass(BatchEntity.class);
+		verify(batchRepositoryMock).save(captor.capture());
+
+		final var value = captor.getValue();
+		assertThat(BATCH_ID).isEqualTo(value.getId());
+		assertThat(MUNICIPALITY_ID).isEqualTo(value.getMunicipalityId());
 	}
 }

--- a/src/test/java/se/sundsvall/snailmail/service/BatchServiceTest.java
+++ b/src/test/java/se/sundsvall/snailmail/service/BatchServiceTest.java
@@ -84,21 +84,4 @@ class BatchServiceTest {
 
 		verify(batchRepositoryMock).delete(batchEntity);
 	}
-
-	@Test
-	void createBatch() {
-		final var request = SendSnailMailRequest.builder()
-			.withBatchId(BATCH_ID)
-			.withMunicipalityId(MUNICIPALITY_ID)
-			.build();
-
-		batchService.createBatch(request);
-
-		final var captor = ArgumentCaptor.forClass(BatchEntity.class);
-		verify(batchRepositoryMock).save(captor.capture());
-
-		final var value = captor.getValue();
-		assertThat(value.getId()).isEqualTo(BATCH_ID);
-		assertThat(value.getMunicipalityId()).isEqualTo(MUNICIPALITY_ID);
-	}
 }

--- a/src/test/java/se/sundsvall/snailmail/service/BatchServiceTest.java
+++ b/src/test/java/se/sundsvall/snailmail/service/BatchServiceTest.java
@@ -2,7 +2,6 @@ package se.sundsvall.snailmail.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -44,8 +43,8 @@ class BatchServiceTest {
 		when(batchRepositoryMock.findByMunicipalityIdAndId(MUNICIPALITY_ID, BATCH_ID)).thenReturn(Optional.of(expectedEntity));
 
 		final var result = batchService.getOrCreateBatch(request);
-		assertThat(BATCH_ID).isEqualTo(result.getId());
-		assertThat(MUNICIPALITY_ID).isEqualTo(result.getMunicipalityId());
+		assertThat(result.getId()).isEqualTo(BATCH_ID);
+		assertThat(result.getMunicipalityId()).isEqualTo(MUNICIPALITY_ID);
 
 		verify(batchRepositoryMock, never()).save(any());
 	}
@@ -64,15 +63,15 @@ class BatchServiceTest {
 		when(batchRepositoryMock.save(any(BatchEntity.class))).thenReturn(expectedEntity);
 
 		final var result = batchService.getOrCreateBatch(request);
-		assertThat(BATCH_ID).isEqualTo(result.getId());
-		assertThat(MUNICIPALITY_ID).isEqualTo(result.getMunicipalityId());
+		assertThat(result.getId()).isEqualTo(BATCH_ID);
+		assertThat(result.getMunicipalityId()).isEqualTo(MUNICIPALITY_ID);
 
 		final var captor = ArgumentCaptor.forClass(BatchEntity.class);
 		verify(batchRepositoryMock).save(captor.capture());
 
 		final var value = captor.getValue();
-		assertThat(BATCH_ID).isEqualTo(value.getId());
-		assertThat(MUNICIPALITY_ID).isEqualTo(value.getMunicipalityId());
+		assertThat(value.getId()).isEqualTo(BATCH_ID);
+		assertThat(value.getMunicipalityId()).isEqualTo(MUNICIPALITY_ID);
 	}
 
 	@Test
@@ -83,7 +82,7 @@ class BatchServiceTest {
 
 		batchService.deleteBatch(batchEntity);
 
-		verify(batchRepositoryMock).delete(eq(batchEntity));
+		verify(batchRepositoryMock).delete(batchEntity);
 	}
 
 	@Test
@@ -99,7 +98,7 @@ class BatchServiceTest {
 		verify(batchRepositoryMock).save(captor.capture());
 
 		final var value = captor.getValue();
-		assertThat(BATCH_ID).isEqualTo(value.getId());
-		assertThat(MUNICIPALITY_ID).isEqualTo(value.getMunicipalityId());
+		assertThat(value.getId()).isEqualTo(BATCH_ID);
+		assertThat(value.getMunicipalityId()).isEqualTo(MUNICIPALITY_ID);
 	}
 }

--- a/src/test/java/se/sundsvall/snailmail/service/BatchServiceTest.java
+++ b/src/test/java/se/sundsvall/snailmail/service/BatchServiceTest.java
@@ -1,0 +1,50 @@
+package se.sundsvall.snailmail.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import se.sundsvall.snailmail.api.model.SendSnailMailRequest;
+import se.sundsvall.snailmail.integration.db.BatchRepository;
+import se.sundsvall.snailmail.integration.db.model.BatchEntity;
+
+@ExtendWith(MockitoExtension.class)
+class BatchServiceTest {
+
+	@Mock
+	private BatchRepository batchRepositoryMock;
+
+	@InjectMocks
+	private BatchService batchService;
+
+	@Test
+	void createEntity() {
+		final var batchId = "123";
+		final var municipalityId = "2281";
+		final var request = SendSnailMailRequest.builder()
+			.withBatchId(batchId)
+			.withMunicipalityId(municipalityId)
+			.build();
+		final var expectedEntity = BatchEntity.builder().withId(batchId).build();
+
+		when(batchRepositoryMock.save(any(BatchEntity.class))).thenReturn(expectedEntity);
+
+		final var result = batchService.createEntity(request);
+
+		assertEquals(batchId, result.getId());
+
+		final var captor = ArgumentCaptor.forClass(BatchEntity.class);
+		verify(batchRepositoryMock).save(captor.capture());
+
+		final var value = captor.getValue();
+		assertEquals(batchId, value.getId());
+		assertEquals(municipalityId, value.getMunicipalityId());
+	}
+}

--- a/src/test/java/se/sundsvall/snailmail/service/DepartmentServiceTest.java
+++ b/src/test/java/se/sundsvall/snailmail/service/DepartmentServiceTest.java
@@ -73,20 +73,4 @@ class DepartmentServiceTest {
 		assertThat(value.getName()).isEqualTo(DEPARTMENT_NAME);
 		assertThat(value.getBatchEntity()).isEqualTo(batchEntity);
 	}
-
-	@Test
-	void createDepartment() {
-		final var batchEntity = BatchEntity.builder()
-			.withId(BATCH_ID)
-			.build();
-
-		departmentService.createDepartment(DEPARTMENT_NAME, batchEntity);
-
-		final var captor = ArgumentCaptor.forClass(DepartmentEntity.class);
-		verify(departmentRepositoryMock).save(captor.capture());
-
-		final var value = captor.getValue();
-		assertThat(value.getName()).isEqualTo(DEPARTMENT_NAME);
-		assertThat(value.getBatchEntity()).isEqualTo(batchEntity);
-	}
 }

--- a/src/test/java/se/sundsvall/snailmail/service/DepartmentServiceTest.java
+++ b/src/test/java/se/sundsvall/snailmail/service/DepartmentServiceTest.java
@@ -43,8 +43,8 @@ class DepartmentServiceTest {
 			.thenReturn(Optional.of(expectedEntity));
 
 		final var result = departmentService.getOrCreateDepartment(DEPARTMENT_NAME, batchEntity);
-		assertThat(DEPARTMENT_NAME).isEqualTo(result.getName());
-		assertThat(batchEntity).isEqualTo(result.getBatchEntity());
+		assertThat(result.getName()).isEqualTo(DEPARTMENT_NAME);
+		assertThat(result.getBatchEntity()).isEqualTo(batchEntity);
 
 		verify(departmentRepositoryMock, never()).save(any());
 	}
@@ -64,14 +64,14 @@ class DepartmentServiceTest {
 		when(departmentRepositoryMock.save(any(DepartmentEntity.class))).thenReturn(expectedEntity);
 
 		final var result = departmentService.getOrCreateDepartment(DEPARTMENT_NAME, batchEntity);
-		assertThat(DEPARTMENT_NAME).isEqualTo(result.getName());
+		assertThat(result.getName()).isEqualTo(DEPARTMENT_NAME);
 
 		final var captor = ArgumentCaptor.forClass(DepartmentEntity.class);
 		verify(departmentRepositoryMock).save(captor.capture());
 
 		final var value = captor.getValue();
-		assertThat(DEPARTMENT_NAME).isEqualTo(value.getName());
-		assertThat(batchEntity).isEqualTo(value.getBatchEntity());
+		assertThat(value.getName()).isEqualTo(DEPARTMENT_NAME);
+		assertThat(value.getBatchEntity()).isEqualTo(batchEntity);
 	}
 
 	@Test
@@ -86,7 +86,7 @@ class DepartmentServiceTest {
 		verify(departmentRepositoryMock).save(captor.capture());
 
 		final var value = captor.getValue();
-		assertThat(DEPARTMENT_NAME).isEqualTo(value.getName());
-		assertThat(batchEntity).isEqualTo(value.getBatchEntity());
+		assertThat(value.getName()).isEqualTo(DEPARTMENT_NAME);
+		assertThat(value.getBatchEntity()).isEqualTo(batchEntity);
 	}
 }

--- a/src/test/java/se/sundsvall/snailmail/service/DepartmentServiceTest.java
+++ b/src/test/java/se/sundsvall/snailmail/service/DepartmentServiceTest.java
@@ -1,6 +1,6 @@
 package se.sundsvall.snailmail.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -43,8 +43,8 @@ class DepartmentServiceTest {
 			.thenReturn(Optional.of(expectedEntity));
 
 		final var result = departmentService.getOrCreateDepartment(DEPARTMENT_NAME, batchEntity);
-		assertEquals(DEPARTMENT_NAME, result.getName());
-		assertEquals(batchEntity, result.getBatchEntity());
+		assertThat(DEPARTMENT_NAME).isEqualTo(result.getName());
+		assertThat(batchEntity).isEqualTo(result.getBatchEntity());
 
 		verify(departmentRepositoryMock, never()).save(any());
 	}
@@ -64,13 +64,29 @@ class DepartmentServiceTest {
 		when(departmentRepositoryMock.save(any(DepartmentEntity.class))).thenReturn(expectedEntity);
 
 		final var result = departmentService.getOrCreateDepartment(DEPARTMENT_NAME, batchEntity);
-		assertEquals(DEPARTMENT_NAME, result.getName());
+		assertThat(DEPARTMENT_NAME).isEqualTo(result.getName());
 
 		final var captor = ArgumentCaptor.forClass(DepartmentEntity.class);
 		verify(departmentRepositoryMock).save(captor.capture());
 
 		final var value = captor.getValue();
-		assertEquals(DEPARTMENT_NAME, value.getName());
-		assertEquals(batchEntity, value.getBatchEntity());
+		assertThat(DEPARTMENT_NAME).isEqualTo(value.getName());
+		assertThat(batchEntity).isEqualTo(value.getBatchEntity());
+	}
+
+	@Test
+	void createDepartment() {
+		final var batchEntity = BatchEntity.builder()
+			.withId(BATCH_ID)
+			.build();
+
+		departmentService.createDepartment(DEPARTMENT_NAME, batchEntity);
+
+		final var captor = ArgumentCaptor.forClass(DepartmentEntity.class);
+		verify(departmentRepositoryMock).save(captor.capture());
+
+		final var value = captor.getValue();
+		assertThat(DEPARTMENT_NAME).isEqualTo(value.getName());
+		assertThat(batchEntity).isEqualTo(value.getBatchEntity());
 	}
 }

--- a/src/test/java/se/sundsvall/snailmail/service/DepartmentServiceTest.java
+++ b/src/test/java/se/sundsvall/snailmail/service/DepartmentServiceTest.java
@@ -1,0 +1,76 @@
+package se.sundsvall.snailmail.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import se.sundsvall.snailmail.integration.db.DepartmentRepository;
+import se.sundsvall.snailmail.integration.db.model.BatchEntity;
+import se.sundsvall.snailmail.integration.db.model.DepartmentEntity;
+
+@ExtendWith(MockitoExtension.class)
+class DepartmentServiceTest {
+
+	private static final String DEPARTMENT_NAME = "dept44";
+	private static final String BATCH_ID = "123";
+
+	@Mock
+	private DepartmentRepository departmentRepositoryMock;
+
+	@InjectMocks
+	private DepartmentService departmentService;
+
+	@Test
+	void getOrCreateDepartment_shouldReturnExisting() {
+		final var batchEntity = BatchEntity.builder()
+			.withId(BATCH_ID)
+			.build();
+		final var expectedEntity = DepartmentEntity.builder()
+			.withName(DEPARTMENT_NAME)
+			.withBatchEntity(batchEntity)
+			.build();
+
+		when(departmentRepositoryMock.findByNameAndBatchEntityId(DEPARTMENT_NAME, BATCH_ID))
+			.thenReturn(Optional.of(expectedEntity));
+
+		final var result = departmentService.getOrCreateDepartment(DEPARTMENT_NAME, batchEntity);
+		assertEquals(DEPARTMENT_NAME, result.getName());
+		assertEquals(batchEntity, result.getBatchEntity());
+
+		verify(departmentRepositoryMock, never()).save(any());
+	}
+
+	@Test
+	void getOrCreateDepartment_shouldCreateNewIfNotFound() {
+		final var batchEntity = BatchEntity.builder()
+			.withId(BATCH_ID)
+			.build();
+		final var expectedEntity = DepartmentEntity.builder()
+			.withName(DEPARTMENT_NAME)
+			.withBatchEntity(batchEntity)
+			.build();
+
+		when(departmentRepositoryMock.findByNameAndBatchEntityId(DEPARTMENT_NAME, BATCH_ID))
+			.thenReturn(Optional.empty());
+		when(departmentRepositoryMock.save(any(DepartmentEntity.class))).thenReturn(expectedEntity);
+
+		final var result = departmentService.getOrCreateDepartment(DEPARTMENT_NAME, batchEntity);
+		assertEquals(DEPARTMENT_NAME, result.getName());
+
+		final var captor = ArgumentCaptor.forClass(DepartmentEntity.class);
+		verify(departmentRepositoryMock).save(captor.capture());
+
+		final var value = captor.getValue();
+		assertEquals(DEPARTMENT_NAME, value.getName());
+		assertEquals(batchEntity, value.getBatchEntity());
+	}
+}

--- a/src/test/java/se/sundsvall/snailmail/service/SnailMailServiceTest.java
+++ b/src/test/java/se/sundsvall/snailmail/service/SnailMailServiceTest.java
@@ -3,7 +3,6 @@ package se.sundsvall.snailmail.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -24,8 +23,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.zalando.problem.Problem;
-import se.sundsvall.snailmail.integration.db.BatchRepository;
-import se.sundsvall.snailmail.integration.db.DepartmentRepository;
 import se.sundsvall.snailmail.integration.db.RequestRepository;
 import se.sundsvall.snailmail.integration.db.model.BatchEntity;
 import se.sundsvall.snailmail.integration.db.model.DepartmentEntity;
@@ -43,10 +40,7 @@ class SnailMailServiceTest {
 	private BatchService batchServiceMock;
 
 	@Mock
-	private BatchRepository batchRepositoryMock;
-
-	@Mock
-	private DepartmentRepository departmentRepositoryMock;
+	private DepartmentService departmentServiceMock;
 
 	@Mock
 	private RequestRepository requestRepositoryMock;
@@ -71,141 +65,48 @@ class SnailMailServiceTest {
 		var batchEntity = BatchEntity.builder().withId(BATCH_ID).build();
 		var request = buildSendSnailMailRequest();
 		when(semaphoreMock.tryAcquire(10L, TimeUnit.SECONDS)).thenReturn(true);
-		when(batchServiceMock.getRepository()).thenReturn(batchRepositoryMock);
-		when(batchRepositoryMock.findByMunicipalityIdAndId(MUNICIPALITY_ID, request.getBatchId())).thenReturn(Optional.ofNullable(batchEntity));
-		when(departmentRepositoryMock.findByNameAndBatchEntityId(any(String.class), anyString())).thenReturn(Optional.ofNullable(DepartmentEntity.builder().build()));
+		when(batchServiceMock.getOrCreateBatch(request)).thenReturn(batchEntity);
+		when(departmentServiceMock.getOrCreateDepartment(request.getDepartment(), batchEntity)).thenReturn(DepartmentEntity.builder().build());
 
 		snailMailService.sendSnailMail(request);
 
 		verify(semaphoreMock).tryAcquire(10L, TimeUnit.SECONDS);
-		verify(batchRepositoryMock).findByMunicipalityIdAndId(MUNICIPALITY_ID, request.getBatchId());
-		verify(departmentRepositoryMock).findByNameAndBatchEntityId("someDepartment", batchEntity.getId());
+		verify(batchServiceMock).getOrCreateBatch(request);
+		verify(departmentServiceMock).getOrCreateDepartment("someDepartment", batchEntity);
 		verify(requestRepositoryMock).save(any(RequestEntity.class));
 		verify(semaphoreMock).release();
-		verifyNoMoreInteractions(batchServiceMock, batchRepositoryMock, departmentRepositoryMock, requestRepositoryMock, semaphoreMock);
+		verifyNoMoreInteractions(batchServiceMock, departmentServiceMock, requestRepositoryMock, semaphoreMock);
 		verifyNoInteractions(sambaIntegrationMock);
 	}
 
 	@Test
-	void sendMailWithNewBatch() throws InterruptedException {
-		var batchEntity = BatchEntity.builder().withId(BATCH_ID).build();
-		var departmentEntity = DepartmentEntity.builder().build();
-		var request = buildSendSnailMailRequest();
+	void sendBatchWithNoBatchFound() {
+		when(batchServiceMock.findBatchByMunicipalityIdAndId(MUNICIPALITY_ID, BATCH_ID)).thenReturn(Optional.empty());
 
-		when(semaphoreMock.tryAcquire(10L, TimeUnit.SECONDS)).thenReturn(true);
-		when(batchServiceMock.createEntity(request)).thenReturn(batchEntity);
-		when(batchServiceMock.getRepository()).thenReturn(batchRepositoryMock);
-		when(batchRepositoryMock.findByMunicipalityIdAndId(MUNICIPALITY_ID, request.getBatchId())).thenReturn(Optional.empty());
-		when(departmentRepositoryMock.findByNameAndBatchEntityId(anyString(), anyString())).thenReturn(Optional.empty());
-		when(departmentRepositoryMock.save(any(DepartmentEntity.class))).thenReturn(departmentEntity);
-		when(requestRepositoryMock.save(any(RequestEntity.class))).thenReturn(RequestEntity.builder().build());
+		assertThatThrownBy(() -> snailMailService.sendBatch(MUNICIPALITY_ID, BATCH_ID))
+			.isInstanceOf(Problem.class)
+			.hasMessage("No batch found: Failed to fetch batch data from database");
 
-		snailMailService.sendSnailMail(request);
-
-		verify(semaphoreMock).tryAcquire(10L, TimeUnit.SECONDS);
-		verify(batchServiceMock).createEntity(request);
-		verify(batchRepositoryMock).findByMunicipalityIdAndId(MUNICIPALITY_ID, request.getBatchId());
-		verify(departmentRepositoryMock).findByNameAndBatchEntityId("someDepartment", batchEntity.getId());
-		verify(departmentRepositoryMock).save(any(DepartmentEntity.class));
-		verify(requestRepositoryMock).save(any(RequestEntity.class));
-		verify(semaphoreMock).release();
-		verifyNoMoreInteractions(batchServiceMock, batchRepositoryMock, departmentRepositoryMock, requestRepositoryMock, semaphoreMock);
-		verifyNoInteractions(sambaIntegrationMock);
-	}
-
-	@Test
-	void sendMailWithNewDepartment() throws InterruptedException {
-		var batchEntity = BatchEntity.builder().build();
-		var request = buildSendSnailMailRequest();
-
-		when(semaphoreMock.tryAcquire(10L, TimeUnit.SECONDS)).thenReturn(true);
-		when(batchServiceMock.getRepository()).thenReturn(batchRepositoryMock);
-		when(batchRepositoryMock.findByMunicipalityIdAndId(MUNICIPALITY_ID, request.getBatchId())).thenReturn(Optional.ofNullable(batchEntity));
-		when(departmentRepositoryMock.findByNameAndBatchEntityId(any(String.class), any())).thenReturn(Optional.empty());
-		when(departmentRepositoryMock.save(any(DepartmentEntity.class))).thenReturn(DepartmentEntity.builder().build());
-		when(requestRepositoryMock.save(any(RequestEntity.class))).thenReturn(RequestEntity.builder().build());
-
-		snailMailService.sendSnailMail(request);
-
-		verify(semaphoreMock).tryAcquire(10L, TimeUnit.SECONDS);
-		verify(batchRepositoryMock).findByMunicipalityIdAndId(MUNICIPALITY_ID, request.getBatchId());
-		verify(departmentRepositoryMock).findByNameAndBatchEntityId(anyString(), any());
-		verify(departmentRepositoryMock).save(any(DepartmentEntity.class));
-		verify(requestRepositoryMock).save(any(RequestEntity.class));
-		verify(semaphoreMock).release();
-		verifyNoMoreInteractions(batchServiceMock, batchRepositoryMock, departmentRepositoryMock, requestRepositoryMock, semaphoreMock);
-		verifyNoInteractions(sambaIntegrationMock);
-	}
-
-	@Test
-	void sendMailWithNewBatchAndDepartment() throws InterruptedException {
-		var request = buildSendSnailMailRequest();
-		var batchEntity = BatchEntity.builder().build();
-
-		when(semaphoreMock.tryAcquire(10L, TimeUnit.SECONDS)).thenReturn(true);
-		when(batchServiceMock.createEntity(request)).thenReturn(batchEntity);
-		when(batchServiceMock.getRepository()).thenReturn(batchRepositoryMock);
-		when(batchRepositoryMock.findByMunicipalityIdAndId(MUNICIPALITY_ID, request.getBatchId())).thenReturn(Optional.empty());
-		when(departmentRepositoryMock.findByNameAndBatchEntityId(any(String.class), any())).thenReturn(Optional.empty());
-		when(departmentRepositoryMock.save(any(DepartmentEntity.class))).thenReturn(DepartmentEntity.builder().build());
-
-		snailMailService.sendSnailMail(request);
-
-		verify(semaphoreMock).tryAcquire(10L, TimeUnit.SECONDS);
-		verify(batchServiceMock).createEntity(request);
-		verify(batchRepositoryMock).findByMunicipalityIdAndId(MUNICIPALITY_ID, request.getBatchId());
-		verify(departmentRepositoryMock).findByNameAndBatchEntityId(anyString(), any());
-		verify(departmentRepositoryMock).save(any(DepartmentEntity.class));
-		verify(requestRepositoryMock).save(any(RequestEntity.class));
-		verify(semaphoreMock).release();
-		verifyNoMoreInteractions(batchServiceMock, batchRepositoryMock, departmentRepositoryMock, requestRepositoryMock, semaphoreMock);
-		verifyNoInteractions(sambaIntegrationMock);
-	}
-
-	@Test
-	void sendMailWithNewBatchAndDepartmentAndCitizen() throws InterruptedException {
-		var request = buildSendSnailMailRequest();
-		var batchEntity = BatchEntity.builder().build();
-
-		when(semaphoreMock.tryAcquire(10L, TimeUnit.SECONDS)).thenReturn(true);
-		when(batchServiceMock.createEntity(request)).thenReturn(batchEntity);
-		when(batchServiceMock.getRepository()).thenReturn(batchRepositoryMock);
-		when(batchRepositoryMock.findByMunicipalityIdAndId(MUNICIPALITY_ID, request.getBatchId())).thenReturn(Optional.empty());
-		when(departmentRepositoryMock.findByNameAndBatchEntityId(any(String.class), any())).thenReturn(Optional.empty());
-		when(departmentRepositoryMock.save(any(DepartmentEntity.class))).thenReturn(DepartmentEntity.builder().build());
-
-		snailMailService.sendSnailMail(request);
-
-		verify(semaphoreMock).tryAcquire(10L, TimeUnit.SECONDS);
-		verify(batchServiceMock).createEntity(request);
-		verify(batchRepositoryMock).findByMunicipalityIdAndId(MUNICIPALITY_ID, request.getBatchId());
-		verify(departmentRepositoryMock).findByNameAndBatchEntityId(any(String.class), any());
-		verify(departmentRepositoryMock).save(any(DepartmentEntity.class));
-		verify(requestRepositoryMock).save(any(RequestEntity.class));
-		verify(semaphoreMock).release();
-		verifyNoMoreInteractions(batchServiceMock, batchRepositoryMock, departmentRepositoryMock, requestRepositoryMock, semaphoreMock, semaphoreMock);
-		verifyNoInteractions(sambaIntegrationMock);
+		verify(batchServiceMock).findBatchByMunicipalityIdAndId(MUNICIPALITY_ID, BATCH_ID);
+		verifyNoMoreInteractions(batchServiceMock);
+		verifyNoInteractions(departmentServiceMock, sambaIntegrationMock, requestRepositoryMock);
 	}
 
 	@Test
 	void sendMailWithNewBatchAndDepartmentWithAddress() throws InterruptedException {
 		var request = buildSendSnailMailRequest().withAddress(buildSendSnailMailAddress());
-		var batchEntity = BatchEntity.builder().build();
+		var batch = BatchEntity.builder().withId(BATCH_ID).build();
+		var department = DepartmentEntity.builder().withName(request.getDepartment()).build();
 
 		when(semaphoreMock.tryAcquire(10L, TimeUnit.SECONDS)).thenReturn(true);
-		when(batchServiceMock.createEntity(request)).thenReturn(batchEntity);
-		when(batchServiceMock.getRepository()).thenReturn(batchRepositoryMock);
-		when(batchRepositoryMock.findByMunicipalityIdAndId(MUNICIPALITY_ID, request.getBatchId())).thenReturn(Optional.empty());
-		when(departmentRepositoryMock.findByNameAndBatchEntityId(any(String.class), any())).thenReturn(Optional.empty());
-		when(departmentRepositoryMock.save(any(DepartmentEntity.class))).thenReturn(DepartmentEntity.builder().build());
+		when(batchServiceMock.getOrCreateBatch(request)).thenReturn(batch);
+		when(departmentServiceMock.getOrCreateDepartment(request.getDepartment(), batch)).thenReturn(department);
 
 		snailMailService.sendSnailMail(request);
 
 		verify(semaphoreMock).tryAcquire(10L, TimeUnit.SECONDS);
-		verify(batchServiceMock).createEntity(request);
-		verify(batchRepositoryMock).findByMunicipalityIdAndId(MUNICIPALITY_ID, request.getBatchId());
-		verify(departmentRepositoryMock).findByNameAndBatchEntityId(any(String.class), any());
-		verify(departmentRepositoryMock).save(any(DepartmentEntity.class));
+		verify(batchServiceMock).getOrCreateBatch(request);
+		verify(departmentServiceMock).getOrCreateDepartment(request.getDepartment(), batch);
 		verify(requestRepositoryMock).save(requestEntityArgumentCaptor.capture());
 		verify(semaphoreMock).release();
 
@@ -220,129 +121,8 @@ class SnailMailServiceTest {
 			assertThat(recipientEntity.getCity()).isEqualTo(request.getAddress().getCity());
 			assertThat(recipientEntity.getCareOf()).isEqualTo(request.getAddress().getCareOf());
 		});
-		verifyNoMoreInteractions(batchServiceMock, batchRepositoryMock, departmentRepositoryMock, requestRepositoryMock, semaphoreMock);
-		verifyNoInteractions(sambaIntegrationMock);
-	}
 
-	/**
-	 * Tests the scenario where sambaActive is true and sftpActive is false
-	 */
-	@Test
-	void sendBatch_1() {
-		var batchEntity = BatchEntity.builder().build();
-
-		when(batchServiceMock.getRepository()).thenReturn(batchRepositoryMock);
-		when(batchRepositoryMock.findByMunicipalityIdAndId(MUNICIPALITY_ID, BATCH_ID)).thenReturn(Optional.ofNullable(batchEntity));
-		ReflectionTestUtils.setField(snailMailService, "sambaActive", true);
-		ReflectionTestUtils.setField(snailMailService, "sftpActive", false);
-
-		snailMailService.sendBatch(MUNICIPALITY_ID, BATCH_ID);
-
-		verify(batchRepositoryMock).findByMunicipalityIdAndId(MUNICIPALITY_ID, BATCH_ID);
-		verify(sambaIntegrationMock).writeBatchDataToSambaShare(any(BatchEntity.class));
-		verify(batchRepositoryMock).delete(any(BatchEntity.class));
-		verifyNoMoreInteractions(batchRepositoryMock, sambaIntegrationMock);
-		verifyNoInteractions(departmentRepositoryMock, requestRepositoryMock);
-	}
-
-	/**
-	 * Tests the scenario where sambaActive is false and sftpActive is true
-	 */
-	@Test
-	void sendBatch_2() {
-		var batchEntity = BatchEntity.builder().build();
-
-		when(batchServiceMock.getRepository()).thenReturn(batchRepositoryMock);
-		when(batchRepositoryMock.findByMunicipalityIdAndId(MUNICIPALITY_ID, BATCH_ID)).thenReturn(Optional.ofNullable(batchEntity));
-		ReflectionTestUtils.setField(snailMailService, "sambaActive", false);
-		ReflectionTestUtils.setField(snailMailService, "sftpActive", true);
-
-		snailMailService.sendBatch(MUNICIPALITY_ID, BATCH_ID);
-
-		verify(batchRepositoryMock).findByMunicipalityIdAndId(MUNICIPALITY_ID, BATCH_ID);
-		verify(sftpIntegrationMock).writeBatchDataToSftp(any(BatchEntity.class));
-		verify(batchRepositoryMock).delete(any(BatchEntity.class));
-		verifyNoMoreInteractions(batchRepositoryMock, sambaIntegrationMock);
-		verifyNoInteractions(departmentRepositoryMock, requestRepositoryMock);
-	}
-
-	/**
-	 * Tests the scenario where sambaActive is false and sftpActive is false
-	 */
-	@Test
-	void sendBatch_3() {
-		var batchEntity = BatchEntity.builder().build();
-
-		when(batchServiceMock.getRepository()).thenReturn(batchRepositoryMock);
-		when(batchRepositoryMock.findByMunicipalityIdAndId(MUNICIPALITY_ID, BATCH_ID)).thenReturn(Optional.ofNullable(batchEntity));
-		ReflectionTestUtils.setField(snailMailService, "sambaActive", false);
-		ReflectionTestUtils.setField(snailMailService, "sftpActive", false);
-
-		assertThatThrownBy(() -> snailMailService.sendBatch(MUNICIPALITY_ID, BATCH_ID))
-			.isInstanceOf(Problem.class)
-			.hasMessage("Internal Server Error: No integration active");
-
-		verify(batchRepositoryMock).findByMunicipalityIdAndId(MUNICIPALITY_ID, BATCH_ID);
-		verify(batchRepositoryMock, never()).delete(any(BatchEntity.class));
-		verifyNoMoreInteractions(batchRepositoryMock);
-		verifyNoInteractions(departmentRepositoryMock, requestRepositoryMock, sambaIntegrationMock);
-	}
-
-	/**
-	 * Tests the scenario where sambaActive is true and sftpActive is true
-	 */
-	@Test
-	void sendBatch_4() {
-		var batchEntity = BatchEntity.builder().build();
-
-		when(batchServiceMock.getRepository()).thenReturn(batchRepositoryMock);
-		when(batchRepositoryMock.findByMunicipalityIdAndId(MUNICIPALITY_ID, BATCH_ID)).thenReturn(Optional.ofNullable(batchEntity));
-		ReflectionTestUtils.setField(snailMailService, "sambaActive", true);
-		ReflectionTestUtils.setField(snailMailService, "sftpActive", true);
-
-		snailMailService.sendBatch(MUNICIPALITY_ID, BATCH_ID);
-
-		verify(batchRepositoryMock).findByMunicipalityIdAndId(MUNICIPALITY_ID, BATCH_ID);
-		verify(batchRepositoryMock).delete(any(BatchEntity.class));
-		verify(sftpIntegrationMock).writeBatchDataToSftp(any(BatchEntity.class));
-		verify(sambaIntegrationMock).writeBatchDataToSambaShare(any(BatchEntity.class));
-		verifyNoMoreInteractions(batchRepositoryMock, sftpIntegrationMock, sambaIntegrationMock);
-		verifyNoInteractions(departmentRepositoryMock, requestRepositoryMock);
-	}
-
-	@Test
-	void sendBatchWithNoBatchFound() {
-		when(batchServiceMock.getRepository()).thenReturn(batchRepositoryMock);
-		when(batchRepositoryMock.findByMunicipalityIdAndId(MUNICIPALITY_ID, BATCH_ID)).thenReturn(Optional.empty());
-
-		assertThatThrownBy(() -> snailMailService.sendBatch(MUNICIPALITY_ID, BATCH_ID))
-			.isInstanceOf(Problem.class)
-			.hasMessage("No batch found: Failed to fetch batch data from database");
-
-		verify(batchRepositoryMock).findByMunicipalityIdAndId(MUNICIPALITY_ID, BATCH_ID);
-		verifyNoMoreInteractions(batchRepositoryMock);
-		verifyNoInteractions(departmentRepositoryMock, sambaIntegrationMock, requestRepositoryMock);
-	}
-
-	@Test
-	void sendBatchWithoutEnvelopeType() throws InterruptedException {
-		var batchEntity = BatchEntity.builder().withId(BATCH_ID).build();
-		var request = buildSendSnailMailRequest();
-		request.getAttachments().getFirst().setEnvelopeType(null);
-
-		when(semaphoreMock.tryAcquire(10L, TimeUnit.SECONDS)).thenReturn(true);
-		when(batchServiceMock.getRepository()).thenReturn(batchRepositoryMock);
-		when(batchRepositoryMock.findByMunicipalityIdAndId(MUNICIPALITY_ID, request.getBatchId())).thenReturn(Optional.ofNullable(batchEntity));
-		when(departmentRepositoryMock.findByNameAndBatchEntityId(any(String.class), anyString())).thenReturn(Optional.ofNullable(DepartmentEntity.builder().build()));
-
-		snailMailService.sendSnailMail(request);
-
-		verify(semaphoreMock).tryAcquire(10L, TimeUnit.SECONDS);
-		verify(batchRepositoryMock).findByMunicipalityIdAndId(MUNICIPALITY_ID, request.getBatchId());
-		verify(departmentRepositoryMock).findByNameAndBatchEntityId(any(String.class), anyString());
-		verify(requestRepositoryMock).save(any());
-		verify(semaphoreMock).release();
-		verifyNoMoreInteractions(batchRepositoryMock, departmentRepositoryMock, requestRepositoryMock, semaphoreMock);
+		verifyNoMoreInteractions(batchServiceMock, departmentServiceMock, requestRepositoryMock, semaphoreMock);
 		verifyNoInteractions(sambaIntegrationMock);
 	}
 
@@ -359,6 +139,72 @@ class SnailMailServiceTest {
 		verify(semaphoreMock).tryAcquire(10L, TimeUnit.SECONDS);
 		verify(semaphoreMock).release();
 		verifyNoMoreInteractions(semaphoreMock);
-		verifyNoInteractions(batchServiceMock, batchRepositoryMock, departmentRepositoryMock, requestRepositoryMock, sambaIntegrationMock);
+		verifyNoInteractions(batchServiceMock, departmentServiceMock, requestRepositoryMock, sambaIntegrationMock);
+	}
+
+	@Test
+	void sendBatch_sambaOnly() {
+		var batch = BatchEntity.builder().build();
+		when(batchServiceMock.findBatchByMunicipalityIdAndId(MUNICIPALITY_ID, BATCH_ID)).thenReturn(Optional.of(batch));
+		ReflectionTestUtils.setField(snailMailService, "sambaActive", true);
+		ReflectionTestUtils.setField(snailMailService, "sftpActive", false);
+
+		snailMailService.sendBatch(MUNICIPALITY_ID, BATCH_ID);
+
+		verify(batchServiceMock).findBatchByMunicipalityIdAndId(MUNICIPALITY_ID, BATCH_ID);
+		verify(sambaIntegrationMock).writeBatchDataToSambaShare(batch);
+		verify(batchServiceMock).deleteBatch(batch);
+		verifyNoMoreInteractions(batchServiceMock, sambaIntegrationMock);
+		verifyNoInteractions(departmentServiceMock, requestRepositoryMock);
+	}
+
+	@Test
+	void sendBatch_sftpOnly() {
+		var batch = BatchEntity.builder().build();
+		when(batchServiceMock.findBatchByMunicipalityIdAndId(MUNICIPALITY_ID, BATCH_ID)).thenReturn(Optional.of(batch));
+		ReflectionTestUtils.setField(snailMailService, "sambaActive", false);
+		ReflectionTestUtils.setField(snailMailService, "sftpActive", true);
+
+		snailMailService.sendBatch(MUNICIPALITY_ID, BATCH_ID);
+
+		verify(batchServiceMock).findBatchByMunicipalityIdAndId(MUNICIPALITY_ID, BATCH_ID);
+		verify(sftpIntegrationMock).writeBatchDataToSftp(batch);
+		verify(batchServiceMock).deleteBatch(batch);
+		verifyNoMoreInteractions(batchServiceMock, sftpIntegrationMock);
+		verifyNoInteractions(departmentServiceMock, requestRepositoryMock);
+	}
+
+	@Test
+	void sendBatch_bothIntegrations() {
+		var batch = BatchEntity.builder().build();
+		when(batchServiceMock.findBatchByMunicipalityIdAndId(MUNICIPALITY_ID, BATCH_ID)).thenReturn(Optional.of(batch));
+		ReflectionTestUtils.setField(snailMailService, "sambaActive", true);
+		ReflectionTestUtils.setField(snailMailService, "sftpActive", true);
+
+		snailMailService.sendBatch(MUNICIPALITY_ID, BATCH_ID);
+
+		verify(batchServiceMock).findBatchByMunicipalityIdAndId(MUNICIPALITY_ID, BATCH_ID);
+		verify(sambaIntegrationMock).writeBatchDataToSambaShare(batch);
+		verify(sftpIntegrationMock).writeBatchDataToSftp(batch);
+		verify(batchServiceMock).deleteBatch(batch);
+		verifyNoMoreInteractions(batchServiceMock, sambaIntegrationMock, sftpIntegrationMock);
+		verifyNoInteractions(departmentServiceMock, requestRepositoryMock);
+	}
+
+	@Test
+	void sendBatch_noIntegrationActive() {
+		var batch = BatchEntity.builder().build();
+		when(batchServiceMock.findBatchByMunicipalityIdAndId(MUNICIPALITY_ID, BATCH_ID)).thenReturn(Optional.of(batch));
+		ReflectionTestUtils.setField(snailMailService, "sambaActive", false);
+		ReflectionTestUtils.setField(snailMailService, "sftpActive", false);
+
+		assertThatThrownBy(() -> snailMailService.sendBatch(MUNICIPALITY_ID, BATCH_ID))
+			.isInstanceOf(Problem.class)
+			.hasMessage("Internal Server Error: No integration active");
+
+		verify(batchServiceMock).findBatchByMunicipalityIdAndId(MUNICIPALITY_ID, BATCH_ID);
+		verify(batchServiceMock, never()).deleteBatch(batch);
+		verifyNoMoreInteractions(batchServiceMock);
+		verifyNoInteractions(departmentServiceMock, requestRepositoryMock, sambaIntegrationMock, sftpIntegrationMock);
 	}
 }


### PR DESCRIPTION
This fixes a race condition where simultaneous calls could attempt to insert the same batch causing conflicts due to uncommitted entities.

By moving the insert to a separate transaction the batch entity is committed immediately and can be read by concurrent threads waiting for the semaphore lock.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
