### PR TITLE
HYDRAN-2435: fix concurrent duplicate department creation

### DIFF
--- a/src/main/java/se/sundsvall/snailmail/integration/db/model/BatchEntity.java
+++ b/src/main/java/se/sundsvall/snailmail/integration/db/model/BatchEntity.java
@@ -7,9 +7,13 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.PostLoad;
+import jakarta.persistence.PostPersist;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,6 +22,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.With;
 import org.hibernate.annotations.TimeZoneStorage;
+import org.springframework.data.domain.Persistable;
 
 import static lombok.AccessLevel.PACKAGE;
 import static org.hibernate.annotations.TimeZoneStorageType.NORMALIZE;
@@ -30,7 +35,7 @@ import static org.hibernate.annotations.TimeZoneStorageType.NORMALIZE;
 @With(PACKAGE)
 @Entity
 @Table(name = "batch", indexes = @Index(name = "idx_batch_municipality_id", columnList = "municipality_id"))
-public class BatchEntity {
+public class BatchEntity implements Persistable<String> {
 
 	@Id
 	@Column(name = "id")
@@ -49,9 +54,33 @@ public class BatchEntity {
 	@TimeZoneStorage(NORMALIZE)
 	private OffsetDateTime created;
 
+	// The id is assigned (not generated), so Spring Data would treat a non-null id as an existing row and call merge()
+	// instead of persist(). A merge re-SELECTs and, if a concurrent request already committed the row, silently turns
+	// into an UPDATE that overwrites columns such as created (set only by @PrePersist on insert). Reporting the entity
+	// as new forces persist(), so a lost race fails with a primary-key violation that BatchService catches and
+	// recovers from by re-fetching. @PostLoad/@PostPersist flip the flag so a loaded entity is correctly merged.
+	@Builder.Default
+	@Transient
+	private boolean isNew = true;
+
 	@PrePersist
 	public void prePersist() {
-		this.created = OffsetDateTime.now();
+		// Belt-and-suspenders: the mapper already sets created; only default it if the caller left it unset, so
+		// neither a persist nor a (merge-triggered) update can leave created null.
+		if (created == null) {
+			this.created = OffsetDateTime.now(ZoneId.systemDefault());
+		}
+	}
+
+	@Override
+	public boolean isNew() {
+		return isNew;
+	}
+
+	@PostLoad
+	@PostPersist
+	void markNotNew() {
+		this.isNew = false;
 	}
 
 	@Override

--- a/src/main/java/se/sundsvall/snailmail/integration/db/model/DepartmentEntity.java
+++ b/src/main/java/se/sundsvall/snailmail/integration/db/model/DepartmentEntity.java
@@ -13,6 +13,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -30,7 +31,11 @@ import static lombok.AccessLevel.PACKAGE;
 @Builder(setterPrefix = "with")
 @With(PACKAGE)
 @Entity
-@Table(name = "department", indexes = @Index(name = "idx_department_name", columnList = "name"))
+@Table(name = "department",
+	indexes = @Index(name = "idx_department_name", columnList = "name"),
+	uniqueConstraints = @UniqueConstraint(name = "uq_department_batch_name_folder", columnNames = {
+		"batch_id", "name", "folder_name"
+	}))
 public class DepartmentEntity {
 
 	@Id

--- a/src/main/java/se/sundsvall/snailmail/service/BatchCreator.java
+++ b/src/main/java/se/sundsvall/snailmail/service/BatchCreator.java
@@ -1,0 +1,35 @@
+package se.sundsvall.snailmail.service;
+
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Component;
+import se.sundsvall.snailmail.integration.db.BatchRepository;
+import se.sundsvall.snailmail.integration.db.model.BatchEntity;
+
+import static jakarta.transaction.Transactional.TxType.REQUIRES_NEW;
+
+@Component
+public class BatchCreator {
+
+	private final BatchRepository batchRepository;
+
+	BatchCreator(final BatchRepository batchRepository) {
+		this.batchRepository = batchRepository;
+	}
+
+	/**
+	 * Inserts the batch in its own new transaction. BatchEntity reports itself as new (see its {@code isNew()}), so
+	 * despite its assigned id Spring Data issues a persist() (INSERT) rather than a merge — a merge could silently turn
+	 * a concurrent collision into an UPDATE that overwrites the existing row. {@code saveAndFlush} forces the INSERT to
+	 * flush synchronously, so a lost race surfaces here as a {@code DataIntegrityViolationException} (primary-key
+	 * violation) that rolls back only this inner transaction, leaving the caller's transaction/session clean for a
+	 * re-fetch.
+	 *
+	 * <p>
+	 * Must be {@code public}: Spring's proxy-based {@code @Transactional} is silently ignored on non-public methods,
+	 * which would collapse this insert into the caller's transaction and defeat the REQUIRES_NEW isolation.
+	 */
+	@Transactional(REQUIRES_NEW)
+	public BatchEntity save(final BatchEntity batchEntity) {
+		return batchRepository.saveAndFlush(batchEntity);
+	}
+}

--- a/src/main/java/se/sundsvall/snailmail/service/BatchService.java
+++ b/src/main/java/se/sundsvall/snailmail/service/BatchService.java
@@ -6,12 +6,15 @@ import java.util.List;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import se.sundsvall.dept44.problem.Problem;
 import se.sundsvall.snailmail.api.model.SendSnailMailRequest;
 import se.sundsvall.snailmail.integration.db.BatchRepository;
 import se.sundsvall.snailmail.integration.db.model.BatchEntity;
 
 import static jakarta.transaction.Transactional.TxType.REQUIRES_NEW;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static se.sundsvall.dept44.util.LogUtils.sanitizeForLogging;
 import static se.sundsvall.snailmail.service.Mapper.toBatchEntity;
 
@@ -21,9 +24,11 @@ public class BatchService {
 	private static final Logger LOGGER = LoggerFactory.getLogger(BatchService.class);
 
 	private final BatchRepository batchRepository;
+	private final BatchCreator batchCreator;
 
-	public BatchService(final BatchRepository batchRepository) {
+	public BatchService(final BatchRepository batchRepository, final BatchCreator batchCreator) {
 		this.batchRepository = batchRepository;
+		this.batchCreator = batchCreator;
 	}
 
 	public Optional<BatchEntity> findBatchByMunicipalityIdAndId(final String municipalityId, final String id) {
@@ -47,8 +52,18 @@ public class BatchService {
 		}
 
 		LOGGER.info("Creating new batch: {}", sanitizeForLogging(request.getBatchId()));
-		final var entity = toBatchEntity(request);
-		return batchRepository.save(entity);
+		try {
+			// Insert in its own (REQUIRES_NEW) transaction so a primary-key violation rolls back only the inner
+			// transaction, leaving this transaction/session usable for the re-fetch below.
+			return batchCreator.save(toBatchEntity(request));
+		} catch (final DataIntegrityViolationException e) {
+			// Lost the race: another thread/pod already inserted the same batch. Re-fetch the committed row.
+			// Relies on READ_COMMITTED isolation (see application.yml) so this query sees the row the winning
+			// transaction just committed; under REPEATABLE READ the first lookup's snapshot would still hide it.
+			LOGGER.info("Batch already created concurrently, re-fetching: {}", sanitizeForLogging(request.getBatchId()));
+			return batchRepository.findByMunicipalityIdAndId(request.getMunicipalityId(), request.getBatchId())
+				.orElseThrow(() -> Problem.valueOf(INTERNAL_SERVER_ERROR, "Batch could not be created or found after unique constraint violation"));
+		}
 	}
 
 	public void deleteBatch(final BatchEntity batchEntity) {

--- a/src/main/java/se/sundsvall/snailmail/service/DepartmentCreator.java
+++ b/src/main/java/se/sundsvall/snailmail/service/DepartmentCreator.java
@@ -1,0 +1,32 @@
+package se.sundsvall.snailmail.service;
+
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Component;
+import se.sundsvall.snailmail.integration.db.DepartmentRepository;
+import se.sundsvall.snailmail.integration.db.model.DepartmentEntity;
+
+import static jakarta.transaction.Transactional.TxType.REQUIRES_NEW;
+
+@Component
+public class DepartmentCreator {
+
+	private final DepartmentRepository departmentRepository;
+
+	DepartmentCreator(final DepartmentRepository departmentRepository) {
+		this.departmentRepository = departmentRepository;
+	}
+
+	/**
+	 * Saves the department in its own new transaction. If a concurrent thread/pod has already inserted the same
+	 * department, the unique-constraint violation surfaces here synchronously (the IDENTITY id forces an immediate
+	 * insert) and rolls back only this transaction, leaving the caller's transaction/session clean for a re-fetch.
+	 *
+	 * <p>
+	 * Must be {@code public}: Spring's proxy-based {@code @Transactional} is silently ignored on non-public
+	 * methods, which would collapse this save into the caller's transaction and defeat the REQUIRES_NEW isolation.
+	 */
+	@Transactional(REQUIRES_NEW)
+	public DepartmentEntity save(final DepartmentEntity departmentEntity) {
+		return departmentRepository.save(departmentEntity);
+	}
+}

--- a/src/main/java/se/sundsvall/snailmail/service/DepartmentService.java
+++ b/src/main/java/se/sundsvall/snailmail/service/DepartmentService.java
@@ -1,15 +1,19 @@
 package se.sundsvall.snailmail.service;
 
 import jakarta.transaction.Transactional;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import se.sundsvall.dept44.problem.Problem;
 import se.sundsvall.dept44.util.LogUtils;
 import se.sundsvall.snailmail.integration.db.DepartmentRepository;
 import se.sundsvall.snailmail.integration.db.model.BatchEntity;
 import se.sundsvall.snailmail.integration.db.model.DepartmentEntity;
 
 import static jakarta.transaction.Transactional.TxType.REQUIRES_NEW;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static se.sundsvall.snailmail.service.Mapper.toDepartment;
 
 @Service
@@ -18,9 +22,11 @@ public class DepartmentService {
 	private static final Logger LOGGER = LoggerFactory.getLogger(DepartmentService.class);
 
 	private final DepartmentRepository departmentRepository;
+	private final DepartmentCreator departmentCreator;
 
-	public DepartmentService(final DepartmentRepository departmentRepository) {
+	public DepartmentService(final DepartmentRepository departmentRepository, final DepartmentCreator departmentCreator) {
 		this.departmentRepository = departmentRepository;
+		this.departmentCreator = departmentCreator;
 	}
 
 	/**
@@ -28,7 +34,13 @@ public class DepartmentService {
 	 */
 	@Transactional(REQUIRES_NEW)
 	public DepartmentEntity getOrCreateDepartment(final String departmentName, final String folderName, final BatchEntity batchEntity) {
-		final var existingDepartmentEntity = departmentRepository.findByNameAndFolderNameAndBatchEntityId(departmentName, folderName, batchEntity.getId());
+		// folder_name is part of a department's identity (it selects the output sub-folder) and of the
+		// uq_department_batch_name_folder unique constraint. A unique index treats NULLs as distinct, which would
+		// defeat the constraint for folder-less departments, so normalize an absent/blank folder to "" and use that
+		// for both the lookup and the insert (the integrations already treat null and blank folders identically).
+		final var normalizedFolderName = Optional.ofNullable(folderName).filter(folder -> !folder.isBlank()).orElse("");
+
+		final var existingDepartmentEntity = departmentRepository.findByNameAndFolderNameAndBatchEntityId(departmentName, normalizedFolderName, batchEntity.getId());
 		if (existingDepartmentEntity.isPresent()) {
 			final var entity = existingDepartmentEntity.get();
 			LOGGER.info("Found existing department: {}", entity.getId());
@@ -38,7 +50,18 @@ public class DepartmentService {
 		LOGGER.info("Creating new department: {} for batch: {}",
 			LogUtils.sanitizeForLogging(departmentName),
 			LogUtils.sanitizeForLogging(batchEntity.getId()));
-		final var entity = toDepartment(departmentName, folderName, batchEntity);
-		return departmentRepository.save(entity);
+
+		try {
+			// Insert in its own (REQUIRES_NEW) transaction so a unique-constraint violation rolls back only the inner
+			// transaction, leaving this transaction/session usable for the re-fetch below.
+			return departmentCreator.save(toDepartment(departmentName, normalizedFolderName, batchEntity));
+		} catch (final DataIntegrityViolationException e) {
+			// Lost the race: another thread/pod already inserted the same department. Re-fetch the committed row.
+			// Relies on READ_COMMITTED isolation (see application.yml) so this query sees the row the winning
+			// transaction just committed; under REPEATABLE READ the first lookup's snapshot would still hide it.
+			LOGGER.info("Department already created concurrently, re-fetching: {}", LogUtils.sanitizeForLogging(departmentName));
+			return departmentRepository.findByNameAndFolderNameAndBatchEntityId(departmentName, normalizedFolderName, batchEntity.getId())
+				.orElseThrow(() -> Problem.valueOf(INTERNAL_SERVER_ERROR, "Department could not be created or found after unique constraint violation"));
+		}
 	}
 }

--- a/src/main/java/se/sundsvall/snailmail/service/Mapper.java
+++ b/src/main/java/se/sundsvall/snailmail/service/Mapper.java
@@ -1,5 +1,7 @@
 package se.sundsvall.snailmail.service;
 
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import se.sundsvall.snailmail.api.model.SendSnailMailRequest;
@@ -73,6 +75,9 @@ public final class Mapper {
 			.withId(request.getBatchId())
 			.withSentBy(request.getIssuer())
 			.withMunicipalityId(request.getMunicipalityId())
+			// Set created here so the value is carried on the entity regardless of whether it is inserted (persist) or,
+			// in a lost-race edge case, updated (merge) — @PrePersist alone only fires on insert.
+			.withCreated(OffsetDateTime.now(ZoneId.systemDefault()))
 			.build();
 	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,9 @@ spring:
     hikari:
       maximum-pool-size: 20
       connection-timeout: 5000
+      # DepartmentService.getOrCreateDepartment relies on READ_COMMITTED: after losing an insert race it re-fetches,
+      # within the same transaction, the row the winning transaction just committed. Under REPEATABLE READ the
+      # snapshot taken by the first lookup would hide that row and the re-fetch would fail with a 500.
       transaction-isolation: TRANSACTION_READ_COMMITTED
   main:
     banner-mode: 'off'
@@ -29,3 +32,13 @@ logbook:
     json-Path:
       - key: '$.attachments[*].content'
         value: '[base64]'
+
+# A lost get-or-create race surfaces as a DataIntegrityViolationException thrown from inside the
+# circuit-breaker-wrapped repository save. It is an expected, benign outcome (the row already exists),
+# so exclude it from breaker accounting to avoid a burst of concurrent collisions tripping the breaker.
+resilience4j:
+  circuitbreaker:
+    instances:
+      departmentRepository:
+        ignore-exceptions:
+          - org.springframework.dao.DataIntegrityViolationException

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,3 +42,6 @@ resilience4j:
       departmentRepository:
         ignore-exceptions:
           - org.springframework.dao.DataIntegrityViolationException
+      batchRepository:
+        ignore-exceptions:
+          - org.springframework.dao.DataIntegrityViolationException

--- a/src/main/resources/db/migration/V1_9__add_department_unique_constraint.sql
+++ b/src/main/resources/db/migration/V1_9__add_department_unique_constraint.sql
@@ -1,0 +1,8 @@
+-- folder_name is part of a department's identity but is nullable; a unique index treats NULLs as distinct, which
+-- would defeat the constraint for folder-less departments. The service now stores "" instead of NULL, so normalize
+-- existing NULL folder names to "" before adding the constraint.
+update department set folder_name = '' where folder_name is null;
+
+alter table department
+    add constraint uq_department_batch_name_folder
+        unique (batch_id, name, folder_name);

--- a/src/test/java/se/sundsvall/snailmail/integration/db/model/BatchEntityTest.java
+++ b/src/test/java/se/sundsvall/snailmail/integration/db/model/BatchEntityTest.java
@@ -16,8 +16,18 @@ class BatchEntityTest {
 
 	@Test
 	void testNoDirtOnCreatedBean() {
-		assertThat(BatchEntity.builder().build()).hasAllNullFieldsOrProperties();
-		assertThat(new BatchEntity()).hasAllNullFieldsOrProperties();
+		// isNew defaults to true (it drives persist-vs-merge), so it is excluded from the all-null check.
+		assertThat(BatchEntity.builder().build()).hasAllNullFieldsOrPropertiesExcept("isNew");
+		assertThat(new BatchEntity()).hasAllNullFieldsOrPropertiesExcept("isNew");
+	}
+
+	@Test
+	void testIsNewLifecycle() {
+		final var batch = new BatchEntity();
+		assertThat(batch.isNew()).isTrue();
+
+		batch.markNotNew();
+		assertThat(batch.isNew()).isFalse();
 	}
 
 	@Test
@@ -26,7 +36,7 @@ class BatchEntityTest {
 		var sentBy = "jeo01doe";
 		var municipalityId = "municipalityId";
 		var department = DepartmentEntity.builder().build();
-		var created = OffsetDateTime.now();
+		var created = OffsetDateTime.parse("2026-01-01T00:00:00Z");
 
 		var batch = BatchEntity.builder()
 			.withId(id)

--- a/src/test/java/se/sundsvall/snailmail/service/BatchCreatorTest.java
+++ b/src/test/java/se/sundsvall/snailmail/service/BatchCreatorTest.java
@@ -1,0 +1,39 @@
+package se.sundsvall.snailmail.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import se.sundsvall.snailmail.integration.db.BatchRepository;
+import se.sundsvall.snailmail.integration.db.model.BatchEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BatchCreatorTest {
+
+	@Mock
+	private BatchRepository batchRepositoryMock;
+
+	@InjectMocks
+	private BatchCreator batchCreator;
+
+	@Test
+	void save() {
+		final var entity = BatchEntity.builder()
+			.withId("batchId")
+			.build();
+
+		when(batchRepositoryMock.saveAndFlush(entity)).thenReturn(entity);
+
+		final var result = batchCreator.save(entity);
+
+		assertThat(result).isEqualTo(entity);
+		verify(batchRepositoryMock).saveAndFlush(entity);
+		verifyNoMoreInteractions(batchRepositoryMock);
+	}
+}

--- a/src/test/java/se/sundsvall/snailmail/service/BatchServiceTest.java
+++ b/src/test/java/se/sundsvall/snailmail/service/BatchServiceTest.java
@@ -7,13 +7,17 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import se.sundsvall.dept44.problem.Problem;
 import se.sundsvall.snailmail.api.model.SendSnailMailRequest;
 import se.sundsvall.snailmail.integration.db.BatchRepository;
 import se.sundsvall.snailmail.integration.db.model.BatchEntity;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -25,6 +29,9 @@ class BatchServiceTest {
 
 	@Mock
 	private BatchRepository batchRepositoryMock;
+
+	@Mock
+	private BatchCreator batchCreatorMock;
 
 	@InjectMocks
 	private BatchService batchService;
@@ -46,7 +53,7 @@ class BatchServiceTest {
 		assertThat(result.getId()).isEqualTo(BATCH_ID);
 		assertThat(result.getMunicipalityId()).isEqualTo(MUNICIPALITY_ID);
 
-		verify(batchRepositoryMock, never()).save(any());
+		verify(batchCreatorMock, never()).save(any());
 	}
 
 	@Test
@@ -60,18 +67,61 @@ class BatchServiceTest {
 			.withMunicipalityId(MUNICIPALITY_ID)
 			.build();
 
-		when(batchRepositoryMock.save(any(BatchEntity.class))).thenReturn(expectedEntity);
+		when(batchCreatorMock.save(any(BatchEntity.class))).thenReturn(expectedEntity);
 
 		final var result = batchService.getOrCreateBatch(request);
 		assertThat(result.getId()).isEqualTo(BATCH_ID);
 		assertThat(result.getMunicipalityId()).isEqualTo(MUNICIPALITY_ID);
 
 		final var captor = ArgumentCaptor.forClass(BatchEntity.class);
-		verify(batchRepositoryMock).save(captor.capture());
+		verify(batchCreatorMock).save(captor.capture());
 
 		final var value = captor.getValue();
 		assertThat(value.getId()).isEqualTo(BATCH_ID);
 		assertThat(value.getMunicipalityId()).isEqualTo(MUNICIPALITY_ID);
+		// The mapper must populate created so it is never left null, even on a merge-triggered update.
+		assertThat(value.getCreated()).isNotNull();
+	}
+
+	@Test
+	void getOrCreateBatch_shouldRefetchWhenCreatedConcurrently() {
+		final var request = SendSnailMailRequest.builder()
+			.withBatchId(BATCH_ID)
+			.withMunicipalityId(MUNICIPALITY_ID)
+			.build();
+		final var expectedEntity = BatchEntity.builder()
+			.withId(BATCH_ID)
+			.withMunicipalityId(MUNICIPALITY_ID)
+			.build();
+
+		// First lookup finds nothing, the concurrent insert loses the race, the second lookup finds the committed row.
+		when(batchRepositoryMock.findByMunicipalityIdAndId(MUNICIPALITY_ID, BATCH_ID))
+			.thenReturn(Optional.empty(), Optional.of(expectedEntity));
+		when(batchCreatorMock.save(any(BatchEntity.class))).thenThrow(new DataIntegrityViolationException("duplicate"));
+
+		final var result = batchService.getOrCreateBatch(request);
+		assertThat(result).isEqualTo(expectedEntity);
+
+		verify(batchRepositoryMock, times(2)).findByMunicipalityIdAndId(MUNICIPALITY_ID, BATCH_ID);
+		verify(batchCreatorMock).save(any(BatchEntity.class));
+	}
+
+	@Test
+	void getOrCreateBatch_shouldThrowWhenConcurrentInsertAndStillNotFound() {
+		final var request = SendSnailMailRequest.builder()
+			.withBatchId(BATCH_ID)
+			.withMunicipalityId(MUNICIPALITY_ID)
+			.build();
+
+		when(batchRepositoryMock.findByMunicipalityIdAndId(MUNICIPALITY_ID, BATCH_ID)).thenReturn(Optional.empty());
+		when(batchCreatorMock.save(any(BatchEntity.class))).thenThrow(new DataIntegrityViolationException("duplicate"));
+
+		assertThatThrownBy(() -> batchService.getOrCreateBatch(request))
+			.isInstanceOf(Problem.class)
+			.hasMessageContaining("Batch could not be created or found after unique constraint violation");
+
+		verify(batchRepositoryMock, times(2)).findByMunicipalityIdAndId(MUNICIPALITY_ID, BATCH_ID);
+		verify(batchCreatorMock).save(any(BatchEntity.class));
 	}
 
 	@Test

--- a/src/test/java/se/sundsvall/snailmail/service/DepartmentCreatorTest.java
+++ b/src/test/java/se/sundsvall/snailmail/service/DepartmentCreatorTest.java
@@ -1,0 +1,39 @@
+package se.sundsvall.snailmail.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import se.sundsvall.snailmail.integration.db.DepartmentRepository;
+import se.sundsvall.snailmail.integration.db.model.DepartmentEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DepartmentCreatorTest {
+
+	@Mock
+	private DepartmentRepository departmentRepositoryMock;
+
+	@InjectMocks
+	private DepartmentCreator departmentCreator;
+
+	@Test
+	void save() {
+		final var entity = DepartmentEntity.builder()
+			.withName("dept44")
+			.build();
+
+		when(departmentRepositoryMock.save(entity)).thenReturn(entity);
+
+		final var result = departmentCreator.save(entity);
+
+		assertThat(result).isEqualTo(entity);
+		verify(departmentRepositoryMock).save(entity);
+		verifyNoMoreInteractions(departmentRepositoryMock);
+	}
+}

--- a/src/test/java/se/sundsvall/snailmail/service/DepartmentServiceTest.java
+++ b/src/test/java/se/sundsvall/snailmail/service/DepartmentServiceTest.java
@@ -7,13 +7,17 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import se.sundsvall.dept44.problem.Problem;
 import se.sundsvall.snailmail.integration.db.DepartmentRepository;
 import se.sundsvall.snailmail.integration.db.model.BatchEntity;
 import se.sundsvall.snailmail.integration.db.model.DepartmentEntity;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -26,6 +30,9 @@ class DepartmentServiceTest {
 
 	@Mock
 	private DepartmentRepository departmentRepositoryMock;
+
+	@Mock
+	private DepartmentCreator departmentCreatorMock;
 
 	@InjectMocks
 	private DepartmentService departmentService;
@@ -47,7 +54,8 @@ class DepartmentServiceTest {
 		assertThat(result.getName()).isEqualTo(DEPARTMENT_NAME);
 		assertThat(result.getBatchEntity()).isEqualTo(batchEntity);
 
-		verify(departmentRepositoryMock, never()).save(any());
+		verify(departmentRepositoryMock).findByNameAndFolderNameAndBatchEntityId(DEPARTMENT_NAME, FOLDER_NAME, BATCH_ID);
+		verify(departmentCreatorMock, never()).save(any());
 	}
 
 	@Test
@@ -62,16 +70,82 @@ class DepartmentServiceTest {
 
 		when(departmentRepositoryMock.findByNameAndFolderNameAndBatchEntityId(DEPARTMENT_NAME, FOLDER_NAME, BATCH_ID))
 			.thenReturn(Optional.empty());
-		when(departmentRepositoryMock.save(any(DepartmentEntity.class))).thenReturn(expectedEntity);
+		when(departmentCreatorMock.save(any(DepartmentEntity.class))).thenReturn(expectedEntity);
 
 		final var result = departmentService.getOrCreateDepartment(DEPARTMENT_NAME, FOLDER_NAME, batchEntity);
 		assertThat(result.getName()).isEqualTo(DEPARTMENT_NAME);
 
 		final var captor = ArgumentCaptor.forClass(DepartmentEntity.class);
-		verify(departmentRepositoryMock).save(captor.capture());
+		verify(departmentCreatorMock).save(captor.capture());
 
 		final var value = captor.getValue();
 		assertThat(value.getName()).isEqualTo(DEPARTMENT_NAME);
 		assertThat(value.getBatchEntity()).isEqualTo(batchEntity);
+	}
+
+	@Test
+	void getOrCreateDepartment_shouldNormalizeBlankFolderNameToEmpty() {
+		final var batchEntity = BatchEntity.builder()
+			.withId(BATCH_ID)
+			.build();
+		final var expectedEntity = DepartmentEntity.builder()
+			.withName(DEPARTMENT_NAME)
+			.withFolderName("")
+			.withBatchEntity(batchEntity)
+			.build();
+
+		when(departmentRepositoryMock.findByNameAndFolderNameAndBatchEntityId(DEPARTMENT_NAME, "", BATCH_ID))
+			.thenReturn(Optional.empty());
+		when(departmentCreatorMock.save(any(DepartmentEntity.class))).thenReturn(expectedEntity);
+
+		final var result = departmentService.getOrCreateDepartment(DEPARTMENT_NAME, null, batchEntity);
+		assertThat(result.getFolderName()).isEqualTo("");
+
+		final var captor = ArgumentCaptor.forClass(DepartmentEntity.class);
+		verify(departmentRepositoryMock).findByNameAndFolderNameAndBatchEntityId(DEPARTMENT_NAME, "", BATCH_ID);
+		verify(departmentCreatorMock).save(captor.capture());
+		assertThat(captor.getValue().getFolderName()).isEqualTo("");
+	}
+
+	@Test
+	void getOrCreateDepartment_shouldRefetchWhenCreatedConcurrently() {
+		final var batchEntity = BatchEntity.builder()
+			.withId(BATCH_ID)
+			.build();
+		final var expectedEntity = DepartmentEntity.builder()
+			.withName(DEPARTMENT_NAME)
+			.withBatchEntity(batchEntity)
+			.build();
+
+		// First lookup finds nothing, the concurrent insert loses the race, the second lookup finds the committed row.
+		when(departmentRepositoryMock.findByNameAndFolderNameAndBatchEntityId(DEPARTMENT_NAME, FOLDER_NAME, BATCH_ID))
+			.thenReturn(Optional.empty(), Optional.of(expectedEntity));
+		when(departmentCreatorMock.save(any(DepartmentEntity.class)))
+			.thenThrow(new DataIntegrityViolationException("duplicate"));
+
+		final var result = departmentService.getOrCreateDepartment(DEPARTMENT_NAME, FOLDER_NAME, batchEntity);
+		assertThat(result).isEqualTo(expectedEntity);
+
+		verify(departmentRepositoryMock, times(2)).findByNameAndFolderNameAndBatchEntityId(DEPARTMENT_NAME, FOLDER_NAME, BATCH_ID);
+		verify(departmentCreatorMock).save(any(DepartmentEntity.class));
+	}
+
+	@Test
+	void getOrCreateDepartment_shouldThrowWhenConcurrentInsertAndStillNotFound() {
+		final var batchEntity = BatchEntity.builder()
+			.withId(BATCH_ID)
+			.build();
+
+		when(departmentRepositoryMock.findByNameAndFolderNameAndBatchEntityId(DEPARTMENT_NAME, FOLDER_NAME, BATCH_ID))
+			.thenReturn(Optional.empty());
+		when(departmentCreatorMock.save(any(DepartmentEntity.class)))
+			.thenThrow(new DataIntegrityViolationException("duplicate"));
+
+		assertThatThrownBy(() -> departmentService.getOrCreateDepartment(DEPARTMENT_NAME, FOLDER_NAME, batchEntity))
+			.isInstanceOf(Problem.class)
+			.hasMessageContaining("Department could not be created or found after unique constraint violation");
+
+		verify(departmentRepositoryMock, times(2)).findByNameAndFolderNameAndBatchEntityId(DEPARTMENT_NAME, FOLDER_NAME, BATCH_ID);
+		verify(departmentCreatorMock).save(any(DepartmentEntity.class));
 	}
 }

--- a/src/test/java/se/sundsvall/snailmail/service/MapperTest.java
+++ b/src/test/java/se/sundsvall/snailmail/service/MapperTest.java
@@ -65,6 +65,23 @@ class MapperTest {
 	}
 
 	@Test
+	void toBatchEntityShouldMapCorrectly() {
+		var request = SendSnailMailRequest.builder()
+			.withBatchId("batchId")
+			.withIssuer("issuer")
+			.withMunicipalityId("2281")
+			.build();
+
+		var result = Mapper.toBatchEntity(request);
+
+		assertThat(result).isNotNull();
+		assertThat(result.getId()).isEqualTo("batchId");
+		assertThat(result.getSentBy()).isEqualTo("issuer");
+		assertThat(result.getMunicipalityId()).isEqualTo("2281");
+		assertThat(result.getCreated()).isNotNull();
+	}
+
+	@Test
 	void toRecipientShouldMapCorrectlyForNullAddress() {
 		var result = Mapper.toRecipient(null);
 

--- a/src/test/resources/db/schema.sql
+++ b/src/test/resources/db/schema.sql
@@ -53,7 +53,10 @@
     create index idx_department_name 
        on department (name);
 
-    alter table if exists request 
+    alter table if exists department
+       add constraint uq_department_batch_name_folder unique (batch_id, name, folder_name);
+
+    alter table if exists request
        add constraint uq_request_recipient unique (recipient_id);
 
     alter table if exists attachment 


### PR DESCRIPTION
Two pods calling getOrCreateDepartment concurrently both saw "not found" and both inserted, creating duplicate department rows. Enforce uniqueness at the database and recover from the lost race instead of duplicating.

- Add composite unique constraint uq_department_batch_name_folder (DepartmentEntity + Flyway V1_9).
- Isolate the insert in a DepartmentCreator @Transactional(REQUIRES_NEW) bean so a violation rolls back only the inner transaction; catch DataIntegrityViolationException and re-fetch the committed row.
- Normalize null/blank folder name to "" (InnoDB treats NULLs as distinct, so the constraint would otherwise miss folder-less departments); backfill NULLs.
- Exclude DataIntegrityViolationException from the departmentRepository circuit breaker so collision bursts don't trip it.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
